### PR TITLE
Update raftlog to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raftlog_protobuf"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The FrugalOS Developers"]
 description = "Encoders and decoders of the Protocol-Buffers messages for the constituents defined in `raftlog` crate"
 homepage = "https://github.com/frugalos/raftlog_protobuf"
@@ -15,5 +15,5 @@ travis-ci = {repository = "frugalos/raftlog_protobuf"}
 [dependencies]
 bytecodec = "0.4"
 protobuf_codec = "0.2"
-raftlog = "0.4"
+raftlog = "0.5"
 trackable = "0.2"


### PR DESCRIPTION
raftlog 0.5 を使うようにする変更です。この変更を入れないと、frugalos 側の Cargo.toml で raftlog 0.5 に更新すると依存関係の conflict で frugalos を build できなくなるみたいなので。